### PR TITLE
Fixed issue when with several monitors

### DIFF
--- a/SnowfallApp/Sources/Common/WindowInfo.swift
+++ b/SnowfallApp/Sources/Common/WindowInfo.swift
@@ -42,4 +42,10 @@ class WindowInfo {
         }
         return false
     }
+    
+    func cast(from global: CGRect, to local: CGRect, point: CGPoint) -> CGPoint {
+        let x = point.x - local.origin.x
+        let y = point.y - (global.height - (local.origin.y + local.height))
+        return CGPoint(x: x, y: y)
+    }
 }

--- a/SnowfallApp/Sources/SnowfallApp.swift
+++ b/SnowfallApp/Sources/SnowfallApp.swift
@@ -27,17 +27,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         snowWindows.forEach { $0.close() }
         snowWindows.removeAll()
         
+        var maxX = CGFloat.leastNormalMagnitude
+        var maxY = CGFloat.leastNormalMagnitude
+        
         for screen in NSScreen.screens {
-            createSnowWindow(for: screen)
+            let f = screen.frame
+
+            maxX = max(maxX, f.maxX)
+            maxY = max(maxY, f.maxY)
+        }
+        
+        let globalRect = CGRect(x: 0, y: 0, width: maxX, height: maxY)
+        
+        for screen in NSScreen.screens {
+            createSnowWindow(for: screen, in: globalRect)
         }
     }
     
-    private func createSnowWindow(for screen: NSScreen) {
+    private func createSnowWindow(for screen: NSScreen, in globalRect: CGRect) {
         let screenRect = screen.frame
         
         let window = NSWindow(contentRect: screenRect, styleMask: [.borderless], backing: .buffered, defer: false)
         
-        let metalController = MetalSnowViewController(screenSize: screenRect.size)
+        let metalController = MetalSnowViewController(screenRect: screenRect, globalRect: globalRect)
         window.contentViewController = metalController
         
         window.isOpaque = false

--- a/SnowfallApp/Sources/Views/MetalSnowViewController.swift
+++ b/SnowfallApp/Sources/Views/MetalSnowViewController.swift
@@ -4,17 +4,19 @@ import MetalKit
 class MetalSnowViewController: NSViewController {
     private let mtkView = MTKView()
     private var renderer: SnowRenderer!
-    private let initialSize: CGSize
+    private let screenRect: CGRect
+    private let globalRect: CGRect
     
-    init(screenSize: CGSize) {
-        self.initialSize = screenSize
+    init(screenRect: CGRect, globalRect: CGRect) {
+        self.screenRect = screenRect
+        self.globalRect = globalRect
         super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
     
     override func loadView() {
-        self.view = NSView(frame: CGRect(origin: .zero, size: initialSize))
+        self.view = NSView(frame: CGRect(origin: .zero, size: screenRect.size))
         self.view.wantsLayer = true
         self.view.layer?.backgroundColor = NSColor.clear.cgColor
         
@@ -30,8 +32,8 @@ class MetalSnowViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        renderer = SnowRenderer(mtkView: mtkView, screenSize: initialSize)
-        renderer.mtkView(mtkView, drawableSizeWillChange: initialSize)
+        renderer = SnowRenderer(mtkView: mtkView, screenRect: screenRect, globalRect: globalRect)
+        renderer.mtkView(mtkView, drawableSizeWillChange: screenRect.size)
         mtkView.delegate = renderer
         
         let trackingArea = NSTrackingArea(


### PR DESCRIPTION
Hey!

I noticed an issue where the snow effect doesn’t work correctly on the secondary screen.

## Issues
 - If the active window is on the left screen the right screen mirrors left one
 - If the active window is on the right screen - it doesn't work at all

<img width="434" height="312" alt="image" src="https://github.com/user-attachments/assets/4088aa81-0fdf-4382-b9d5-fa7693ac477c" />

## Reason
The shader was working with each screen separately, and the coordinates of the snowflakes are local to each screen. Meanwhile, `Uniforms.windowRect` which is send in `updateSnowflakes` has global coordinates for all combined screens. 

## Solution
To fix this, I added a conversion of the window coordinates from global to local. So I've added the calculation of the global 'united' display and pass it to each screens' renderer with the origin of each screen, so it can calculate local coordinate of point in global coordinate system.